### PR TITLE
Refactoring precedence logic, moving outside of nodes module.

### DIFF
--- a/ctree/codegen.py
+++ b/ctree/codegen.py
@@ -1,5 +1,6 @@
 from ctree.visitors import NodeVisitor
 from ctree.nodes import *
+from ctree.precedence import *
 
 class CodeGenerator(NodeVisitor):
   """
@@ -34,14 +35,13 @@ class CodeGenerator(NodeVisitor):
     parent = getattr(node, 'parent', None)
     if isinstance(  node, (UnaryOp, BinaryOp)) and \
        isinstance(parent, (UnaryOp, BinaryOp)):
-      prec = node.op.get_precedence()
-      parent_prec = parent.op.get_precedence()
+      prec = get_precedence(node.op)
+      parent_prec = get_precedence(parent.op)
       is_first_child = isinstance(parent, UnaryOp) or \
                       (isinstance(parent, BinaryOp) and node is parent.left)
-      assoc_left = parent.op.is_left_associative()
+      assoc_left = is_left_associative(parent.op)
       if (prec < parent_prec) or \
-         (prec == parent_prec and ((assoc_left and not is_first_child) or \
-                                   (not assoc_left and is_first_child))):
+         (prec == parent_prec and (assoc_left is not is_first_child)):
         return True
     return False
 

--- a/ctree/nodes.py
+++ b/ctree/nodes.py
@@ -219,108 +219,41 @@ class Op:
     def __str__(self):
       return self._c_str
 
-    def get_precedence(self):
-      # flip precedence so higher numbers mean higher precedence
-      return 20 - self.precedence
-
-    def is_left_associative(self):
-      return self.left_assoc
-
-  class _OpPrec2(_Op):
-    precedence = 2
-    left_assoc = True
-
-  class _OpPrec3(_Op):
-    precedence = 3
-    left_assoc = False
-
-  class _OpPrec5(_Op):
-    precedence = 5
-    left_assoc = True
-
-  class _OpPrec6(_Op):
-    precedence = 6
-    left_assoc = True
-
-  class _OpPrec7(_Op):
-    precedence = 7
-    left_assoc = True
-
-  class _OpPrec8(_Op):
-    precedence = 8
-    left_assoc = True
-
-  class _OpPrec9(_Op):
-    precedence = 9
-    left_assoc = True
-
-  class _OpPrec10(_Op):
-    precedence = 10
-    left_assoc = True
-
-  class _OpPrec11(_Op):
-    precedence = 11
-    left_assoc = True
-
-  class _OpPrec12(_Op):
-    precedence = 12
-    left_assoc = True
-
-  class _OpPrec13(_Op):
-    precedence = 13
-    left_assoc = True
-
-  class _OpPrec14(_Op):
-    precedence = 14
-    left_assoc = True
-
-  class _OpPrec15(_Op):
-    precedence = 15
-    left_assoc = False
-
-  class _OpPrec16(_Op):
-    precedence = 16
-    left_assoc = False
-
-  class _OpPrec18(_Op):
-    precedence = 18
-    left_assoc = True
-
-  class PreInc(_OpPrec3):   _c_str = "++"
-  class PreDec(_OpPrec3):   _c_str = "--"
-  class PostInc(_OpPrec2):  _c_str = "++"
-  class PostDec(_OpPrec2):  _c_str = "--"
-  class Ref(_OpPrec3):      _c_str = "&"
-  class Deref(_OpPrec3):    _c_str = "*"
-  class SizeOf(_OpPrec3):   _c_str = "sizeof"
-  class Add(_OpPrec6):      _c_str = "+"
-  class AddUnary(_OpPrec3): _c_str = "+"
-  class Sub(_OpPrec6):      _c_str = "-"
-  class SubUnary(_OpPrec3): _c_str = "-"
-  class Mul(_OpPrec5):      _c_str = "*"
-  class Div(_OpPrec5):      _c_str = "/"
-  class Mod(_OpPrec5):      _c_str = "%"
-  class Gt(_OpPrec8):       _c_str = ">"
-  class Lt(_OpPrec8):       _c_str = "<"
-  class GtE(_OpPrec8):      _c_str = ">="
-  class LtE(_OpPrec8):      _c_str = "<="
-  class Eq(_OpPrec9):       _c_str = "=="
-  class NotEq(_OpPrec9):    _c_str = "!="
-  class BitAnd(_OpPrec10):  _c_str = "&"
-  class BitOr(_OpPrec12):   _c_str = "|"
-  class BitNot(_OpPrec3):   _c_str = "~"
-  class BitShL(_OpPrec7):   _c_str = "<<"
-  class BitShR(_OpPrec7):   _c_str = ">>"
-  class BitXor(_OpPrec11):  _c_str = "^"
-  class And(_OpPrec13):     _c_str = "&&"
-  class Or(_OpPrec14):      _c_str = "||"
-  class Not(_OpPrec3):      _c_str = "!"
-  class Comma(_OpPrec18):   _c_str = ","
-  class Dot(_OpPrec2):      _c_str = "."
-  class Arrow(_OpPrec2):    _c_str = "->"
-  class Assign(_OpPrec16):  _c_str = "="
-  class Cast(_OpPrec3):     _c_str = "??"
-  class ArrayRef(_OpPrec2): _c_str = "??"
+  class PreInc(_Op):   _c_str = "++"
+  class PreDec(_Op):   _c_str = "--"
+  class PostInc(_Op):  _c_str = "++"
+  class PostDec(_Op):  _c_str = "--"
+  class Ref(_Op):      _c_str = "&"
+  class Deref(_Op):    _c_str = "*"
+  class SizeOf(_Op):   _c_str = "sizeof"
+  class Add(_Op):      _c_str = "+"
+  class AddUnary(_Op): _c_str = "+"
+  class Sub(_Op):      _c_str = "-"
+  class SubUnary(_Op): _c_str = "-"
+  class Mul(_Op):      _c_str = "*"
+  class Div(_Op):      _c_str = "/"
+  class Mod(_Op):      _c_str = "%"
+  class Gt(_Op):       _c_str = ">"
+  class Lt(_Op):       _c_str = "<"
+  class GtE(_Op):      _c_str = ">="
+  class LtE(_Op):      _c_str = "<="
+  class Eq(_Op):       _c_str = "=="
+  class NotEq(_Op):    _c_str = "!="
+  class BitAnd(_Op):   _c_str = "&"
+  class BitOr(_Op):    _c_str = "|"
+  class BitNot(_Op):   _c_str = "~"
+  class BitShL(_Op):   _c_str = "<<"
+  class BitShR(_Op):   _c_str = ">>"
+  class BitXor(_Op):   _c_str = "^"
+  class And(_Op):      _c_str = "&&"
+  class Or(_Op):       _c_str = "||"
+  class Not(_Op):      _c_str = "!"
+  class Comma(_Op):    _c_str = ","
+  class Dot(_Op):      _c_str = "."
+  class Arrow(_Op):    _c_str = "->"
+  class Assign(_Op):   _c_str = "="
+  class Cast(_Op):     _c_str = "??"
+  class ArrayRef(_Op): _c_str = "??"
 
 
 # ---------------------------------------------------------------------------

--- a/ctree/precedence.py
+++ b/ctree/precedence.py
@@ -12,72 +12,75 @@ number of parentheses in the generated code.
 # precedence. For the origin of this table see
 # http://en.wikipedia.org/wiki/Operators_in_C_and_C%2B%2B#Operator_precedence
 _EXPR_TO_PRECEDENCE = {
-  PostInc: 2,
-  PostDec: 2,
-  FunctionCall: 2,
-  ArrayRef: 2,
-  Dot: 2,
-  Arrow: 2,
+  'PostInc': 2,
+  'PostDec': 2,
+  'FunctionCall': 2,
+  'ArrayRef': 2,
+  'Dot': 2,
+  'Arrow': 2,
 
-  PreInc: 3,
-  PreDec: 3,
-  #Plus: 3,
-  #Minus: 3,
-  Not: 3,
-  BitNot: 3,
-  # cast: 3,
-  Deref: 3,
-  Ref: 3,
-  SizeOf: 3,
+  'PreInc': 3,
+  'PreDec': 3,
+  #'Plus': 3,
+  # TODO: work out naming schemes for add/sub unary
+  'AddUnary': 3,
+  #'Minus': 3,
+  'SubUnary': 3,
+  'Not': 3,
+  'BitNot': 3,
+  # 'cast': 3,
+  'Deref': 3,
+  'Ref': 3,
+  'SizeOf': 3,
 
-  Mul: 5,
-  Div: 5,
-  Mod: 5,
+  'Mul': 5,
+  'Div': 5,
+  'Mod': 5,
 
-  Add: 6,
-  Sub: 6,
+  'Add': 6,
+  'Sub': 6,
 
-  BitShL: 7,
-  BitShR: 7,
+  'BitShL': 7,
+  'BitShR': 7,
 
-  Lt: 8,
-  LtE: 8,
-  Gt: 8,
-  GtE: 8,
+  'Lt': 8,
+  'LtE': 8,
+  'Gt': 8,
+  'GtE': 8,
 
-  Eq: 9,
-  NotEq: 9,
+  'Eq': 9,
+  'NotEq': 9,
 
-  BitAnd: 10,
+  'BitAnd': 10,
 
-  BitXor: 11,
+  'BitXor': 11,
 
-  BitOr: 12,
+  'BitOr': 12,
 
-  And: 13,
+  'And': 13,
 
-  Or: 14,
+  'Or': 14,
 
-  TernaryOp: 15,
+  'TernaryOp': 15,
 
-  Assign: 16,
-  AddAssign: 16,
-  SubAssign: 16,
-  MulAssign: 16,
-  DivAssign: 16,
-  ModAssign: 16,
-  BitShLAssign: 16,
-  BitShRAssign: 16,
-  BitAndAssign: 16,
-  BitXorAssign: 16,
-  #BitNotAssign: 16,
+  'Assign': 16,
+  'AddAssign': 16,
+  'SubAssign': 16,
+  'MulAssign': 16,
+  'DivAssign': 16,
+  'ModAssign': 16,
+  'BitShLAssign': 16,
+  'BitShRAssign': 16,
+  'BitAndAssign': 16,
+  'BitXorAssign': 16,
+  # 'BitNotAssign': 16,
 
-  Comma: 18,
+  'Comma': 18,
 }
 
 def get_precedence(node):
   try:
-    pred = _EXPR_TO_PRECEDENCE[type(node)]
+    pred = _EXPR_TO_PRECEDENCE[type(node).__name__]
   except KeyError:
     raise Exception("Unable to determine precedence for %s." % type(node).__name__)
   # flip precedence so higher numbers mean higher precedence
@@ -104,8 +107,8 @@ _PRECEDENCE_ASSOCIATES_LTR = {
 def is_left_associative(node):
   try:
     pred = get_precedence(node)
-    ltr = _PRECEDENCE_ASSOCIATES_LTR(pred)
+    ltr = _PRECEDENCE_ASSOCIATES_LTR[20 - pred]
   except KeyError:
-    raise Exception("Cannot determine if operator %s (precedence %d) is left- or right-associative.") \
-      % (type(node).__name__, pred)
+    raise Exception("Cannot determine if operator %s (precedence %d) is left- or right-associative." \
+      % (type(node).__name__, pred))
   return ltr


### PR DESCRIPTION
Moved precedence logic into a separate module.  Right now is_left_associative logic is pretty funky.  Calls get_precedence, but then has to invert the precedences again to properly do the lookup.  Solution is either to lookup precedence from dictionary to find the associativity or invert the associativity dictionary.  Passes tests though.

Also right now it's looking up Precedence by the type(node).**name** . Our naming scheme doesn't match up one to one with the c naming scheme (for Add/Sub).  This is due to Add/Sub deciding whether or not is an unary or binary operation and constructing accordingly.  Should we keep this?  The other option would be to explicitly distinguish between the Add/Plus and Sub/Minus (the way the C naming scheme is) which would mean a separate class and reference for each.
